### PR TITLE
Use NodePort when using no annotations

### DIFF
--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/NoAnnotationsTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/NoAnnotationsTest.java
@@ -66,7 +66,7 @@ public class NoAnnotationsTest {
                 Assert.assertEquals(service.getMetadata().getName(), "helloworld-svc");
                 Assert.assertEquals(service.getMetadata().getLabels().get(KubernetesConstants
                         .KUBERNETES_SELECTOR_KEY), "no_annotation_service");
-                Assert.assertEquals(service.getSpec().getType(), KubernetesConstants.ServiceType.ClusterIP.name());
+                Assert.assertEquals(service.getSpec().getType(), KubernetesConstants.ServiceType.NodePort.name());
                 Assert.assertEquals(service.getSpec().getPorts().size(), 1);
                 Assert.assertEquals(service.getSpec().getPorts().get(0).getPort().intValue(), 9090);
             }
@@ -109,7 +109,7 @@ public class NoAnnotationsTest {
                 Assert.assertEquals(service.getMetadata().getName(), "helloworldep-svc");
                 Assert.assertEquals(service.getMetadata().getLabels().get(KubernetesConstants
                         .KUBERNETES_SELECTOR_KEY), "no_annotation_listener");
-                Assert.assertEquals(service.getSpec().getType(), KubernetesConstants.ServiceType.ClusterIP.name());
+                Assert.assertEquals(service.getSpec().getType(), KubernetesConstants.ServiceType.NodePort.name());
                 Assert.assertEquals(service.getSpec().getPorts().size(), 1);
                 Assert.assertEquals(service.getSpec().getPorts().get(0).getPort().intValue(), 9090);
             }

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/KubernetesPlugin.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/KubernetesPlugin.java
@@ -21,6 +21,7 @@ package org.ballerinax.kubernetes;
 import org.ballerinalang.compiler.JarResolver;
 import org.ballerinalang.compiler.plugins.AbstractCompilerPlugin;
 import org.ballerinalang.compiler.plugins.SupportedAnnotationPackages;
+import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
@@ -36,16 +37,21 @@ import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
 import org.ballerinax.kubernetes.models.KubernetesContext;
 import org.ballerinax.kubernetes.models.KubernetesDataHolder;
 import org.ballerinax.kubernetes.processors.AnnotationProcessorFactory;
+import org.ballerinax.kubernetes.processors.ServiceAnnotationProcessor;
 import org.ballerinax.kubernetes.utils.DependencyValidator;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerinalang.compiler.SourceDirectory;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeInit;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -126,6 +132,26 @@ public class KubernetesPlugin extends AbstractCompilerPlugin {
                 // Generate artifacts for services for all services
                 serviceNodes.forEach(sn -> process(sn, Collections.singletonList(createAnnotation("Deployment"))));
 
+                // Create Service annotation with NodePort service type
+                AnnotationAttachmentNode serviceAnnotation = createAnnotation("Service");
+                BLangRecordLiteral svcRecordLiteral = (BLangRecordLiteral) TreeBuilder.createRecordLiteralNode();
+                serviceAnnotation.setExpression(svcRecordLiteral);
+                
+                BLangLiteral serviceTypeKey = (BLangLiteral) TreeBuilder.createLiteralExpression();
+                serviceTypeKey.value = ServiceAnnotationProcessor.ServiceConfiguration.serviceType.name();
+                serviceTypeKey.type = new BType(TypeTags.STRING, null);
+    
+                BLangLiteral serviceTypeValue = new BLangLiteral();
+                serviceTypeValue.value = KubernetesConstants.ServiceType.NodePort.name();
+                serviceTypeValue.type = new BType(TypeTags.STRING, null);
+    
+                BLangRecordLiteral.BLangRecordKeyValueField serviceTypeRecordField =
+                        new BLangRecordLiteral.BLangRecordKeyValueField();
+                serviceTypeRecordField.key = new BLangRecordLiteral.BLangRecordKey(serviceTypeKey);
+                serviceTypeRecordField.valueExpr = serviceTypeValue;
+                
+                svcRecordLiteral.fields.add(serviceTypeRecordField);
+    
                 // Filter services with 'new Listener()' and generate services
                 for (ServiceNode serviceNode : serviceNodes) {
                     Optional<? extends ExpressionNode> initListener = serviceNode.getAttachedExprs().stream()
@@ -133,7 +159,7 @@ public class KubernetesPlugin extends AbstractCompilerPlugin {
                             .findAny();
 
                     if (initListener.isPresent()) {
-                        serviceNodes.forEach(sn -> process(sn, Collections.singletonList(createAnnotation("Service"))));
+                        serviceNodes.forEach(sn -> process(sn, Collections.singletonList(serviceAnnotation)));
                     }
                 }
 
@@ -145,13 +171,13 @@ public class KubernetesPlugin extends AbstractCompilerPlugin {
                         .map(aex -> (BLangSimpleVarRef) aex)
                         .map(BLangSimpleVarRef::toString)
                         .collect(Collectors.toList());
-
+    
                 // Generate artifacts for listeners attached to services
                 topLevelNodes.stream()
                         .filter(tln -> tln instanceof SimpleVariableNode)
                         .map(tln -> (SimpleVariableNode) tln)
                         .filter(listener -> listenerNamesToExpose.contains(listener.getName().getValue()))
-                        .forEach(listener -> process(listener, Collections.singletonList(createAnnotation("Service"))));
+                        .forEach(listener -> process(listener, Collections.singletonList(serviceAnnotation)));
 
                 // Generate artifacts for main functions
                 topLevelNodes.stream()

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
@@ -249,7 +249,7 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
     /**
      * Enum for Service configurations.
      */
-    private enum ServiceConfiguration {
+    public enum ServiceConfiguration {
         name,
         labels,
         annotations,


### PR DESCRIPTION
## Purpose
> $subject. When generating artifacts without annotations, the kubernetes svc generated has ClusterIP service type. This PR will change it to NodePort.