### PR TITLE
Allow empty/undefined environment variables

### DIFF
--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KnativeUtils.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KnativeUtils.java
@@ -266,7 +266,7 @@ public class KnativeUtils {
             int endIndex = value.indexOf("}", startIndex);
             if (endIndex > 0) {
                 String varName = value.substring(startIndex + 5, endIndex).trim();
-                String resolvedVar = Optional.ofNullable(System.getenv(varName));
+                String resolvedVar = Optional.ofNullable(System.getenv(varName)).orElse("");
                 String rest = (value.length() > endIndex + 1) ? resolveValue(value.substring(endIndex + 1)) : "";
                 return value.substring(0, startIndex) + resolvedVar + rest;
             }

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KnativeUtils.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KnativeUtils.java
@@ -260,15 +260,13 @@ public class KnativeUtils {
      * @param value The user provided value
      * @return The resolved value
      */
-    public static String resolveValue(String value) throws KubernetesPluginException {
+    public static String resolveValue(String value) {
         int startIndex;
         if ((startIndex = value.indexOf("$env{")) >= 0) {
             int endIndex = value.indexOf("}", startIndex);
             if (endIndex > 0) {
                 String varName = value.substring(startIndex + 5, endIndex).trim();
-                String resolvedVar = Optional.ofNullable(System.getenv(varName)).orElseThrow(() ->
-                        new KubernetesPluginException("error resolving value: " + varName +
-                                " is not set in the environment."));
+                String resolvedVar = Optional.ofNullable(System.getenv(varName));
                 String rest = (value.length() > endIndex + 1) ? resolveValue(value.substring(endIndex + 1)) : "";
                 return value.substring(0, startIndex) + resolvedVar + rest;
             }

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KubernetesUtils.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KubernetesUtils.java
@@ -282,7 +282,7 @@ public class KubernetesUtils {
             int endIndex = value.indexOf("}", startIndex);
             if (endIndex > 0) {
                 String varName = value.substring(startIndex + 5, endIndex).trim();
-                String resolvedVar = Optional.ofNullable(System.getenv(varName));
+                String resolvedVar = Optional.ofNullable(System.getenv(varName)).orElse("");
                 String rest = (value.length() > endIndex + 1) ? resolveValue(value.substring(endIndex + 1)) : "";
                 return value.substring(0, startIndex) + resolvedVar + rest;
             }

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KubernetesUtils.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KubernetesUtils.java
@@ -276,15 +276,13 @@ public class KubernetesUtils {
      * @param value The user provided value
      * @return The resolved value
      */
-    public static String resolveValue(String value) throws KubernetesPluginException {
+    public static String resolveValue(String value) {
         int startIndex;
         if ((startIndex = value.indexOf("$env{")) >= 0) {
             int endIndex = value.indexOf("}", startIndex);
             if (endIndex > 0) {
                 String varName = value.substring(startIndex + 5, endIndex).trim();
-                String resolvedVar = Optional.ofNullable(System.getenv(varName)).orElseThrow(() -> 
-                    new KubernetesPluginException("error resolving value: " + varName + 
-                            " is not set in the environment."));
+                String resolvedVar = Optional.ofNullable(System.getenv(varName));
                 String rest = (value.length() > endIndex + 1) ? resolveValue(value.substring(endIndex + 1)) : "";
                 return value.substring(0, startIndex) + resolvedVar + rest;
             }

--- a/kubernetes-extension/src/test/java/org/ballerinax/kubernetes/utils/KubernetesUtilsTest.java
+++ b/kubernetes-extension/src/test/java/org/ballerinax/kubernetes/utils/KubernetesUtilsTest.java
@@ -96,16 +96,12 @@ public class KubernetesUtilsTest {
         env.put("EXAMPLE_FALSE_2", "");
         env.put("EXAMPLE_FALSE_3", null);
         setEnv(env);
-        try {
-            Assert.assertTrue(KubernetesUtils.getBooleanValue("$env{EXAMPLE_TRUE_1}"));
-            Assert.assertTrue(KubernetesUtils.getBooleanValue("$env{EXAMPLE_TRUE_2}"));
-            Assert.assertTrue(KubernetesUtils.getBooleanValue("$env{EXAMPLE_TRUE_3}"));
-            Assert.assertFalse(KubernetesUtils.getBooleanValue("$env{EXAMPLE_FALSE_1}"));
-            Assert.assertFalse(KubernetesUtils.getBooleanValue("$env{EXAMPLE_FALSE_2}"));
-            Assert.assertFalse(KubernetesUtils.getBooleanValue("$env{EXAMPLE_FALSE_3}"));
-        } catch (KubernetesPluginException e) {
-            Assert.fail("Unable to resolve environment variable as boolean");
-        }
+        Assert.assertTrue(KubernetesUtils.getBooleanValue("$env{EXAMPLE_TRUE_1}"));
+        Assert.assertTrue(KubernetesUtils.getBooleanValue("$env{EXAMPLE_TRUE_2}"));
+        Assert.assertTrue(KubernetesUtils.getBooleanValue("$env{EXAMPLE_TRUE_3}"));
+        Assert.assertFalse(KubernetesUtils.getBooleanValue("$env{EXAMPLE_FALSE_1}"));
+        Assert.assertFalse(KubernetesUtils.getBooleanValue("$env{EXAMPLE_FALSE_2}"));
+        Assert.assertFalse(KubernetesUtils.getBooleanValue("$env{EXAMPLE_FALSE_3}"));
     }
 
     @Test

--- a/kubernetes-extension/src/test/java/org/ballerinax/kubernetes/utils/KubernetesUtilsTest.java
+++ b/kubernetes-extension/src/test/java/org/ballerinax/kubernetes/utils/KubernetesUtilsTest.java
@@ -87,6 +87,28 @@ public class KubernetesUtilsTest {
     }
 
     @Test
+    public void resolveBooleanValueTrueTest() throws Exception {
+        Map<String, String> env = new HashMap<>();
+        env.put("EXAMPLE_TRUE_1", true);
+        env.put("EXAMPLE_TRUE_2", " ");
+        env.put("EXAMPLE_TRUE_3", "mattclegg");
+        env.put("EXAMPLE_FALSE_1", false);
+        env.put("EXAMPLE_FALSE_2", "");
+        env.put("EXAMPLE_FALSE_3", null);
+        setEnv(env);
+        try {
+            Assert.assertTrue(KubernetesUtils.getBooleanValue("$env{EXAMPLE_TRUE_1}"));
+            Assert.assertTrue(KubernetesUtils.getBooleanValue("$env{EXAMPLE_TRUE_2}"));
+            Assert.assertTrue(KubernetesUtils.getBooleanValue("$env{EXAMPLE_TRUE_3}"));
+            Assert.assertFalse(KubernetesUtils.getBooleanValue("$env{EXAMPLE_FALSE_1}"));
+            Assert.assertFalse(KubernetesUtils.getBooleanValue("$env{EXAMPLE_FALSE_2}"));
+            Assert.assertFalse(KubernetesUtils.getBooleanValue("$env{EXAMPLE_FALSE_3}"));
+        } catch (KubernetesPluginException e) {
+            Assert.fail("Unable to resolve environment variable as boolean");
+        }
+    }
+
+    @Test
     public void deleteDirectoryTest() throws IOException, KubernetesPluginException {
         File file = tempDirectory.resolve("myfile.txt").toFile();
         Assert.assertTrue(file.createNewFile());

--- a/kubernetes-extension/src/test/java/org/ballerinax/kubernetes/utils/KubernetesUtilsTest.java
+++ b/kubernetes-extension/src/test/java/org/ballerinax/kubernetes/utils/KubernetesUtilsTest.java
@@ -70,6 +70,7 @@ public class KubernetesUtilsTest {
     public void resolveValueTest() throws Exception {
         Map<String, String> env = new HashMap<>();
         env.put("DOCKER_USERNAME", "anuruddhal");
+        env.put("DOCKER_PASSWORD", "");
         setEnv(env);
         try {
             Assert.assertEquals(KubernetesUtils.resolveValue("$env{DOCKER_USERNAME}"), "anuruddhal");
@@ -77,15 +78,14 @@ public class KubernetesUtilsTest {
             Assert.fail("Unable to resolve environment variable");
         }
         try {
-            KubernetesUtils.resolveValue("$env{DOCKER_PASSWORD}");
-            Assert.fail("Env value should be resolved");
+            Assert.assertEquals(KubernetesUtils.resolveValue("$env{DOCKER_PASSWORD}"), "");
+            Assert.assertEquals(KubernetesUtils.resolveValue("$env{DOCKER_UNDEFINED}"), "");
         } catch (KubernetesPluginException e) {
-            Assert.assertEquals(e.getMessage(), "error resolving value: DOCKER_PASSWORD is not set in the " +
-                    "environment.");
+            Assert.fail("Unable to resolve null/blank environment variable");
         }
         Assert.assertEquals(KubernetesUtils.resolveValue("demo"), "demo");
     }
-    
+
     @Test
     public void deleteDirectoryTest() throws IOException, KubernetesPluginException {
         File file = tempDirectory.resolve("myfile.txt").toFile();


### PR DESCRIPTION
## Purpose
Allow empty/undefined environment variables when running the build.

This allows more flexibility for build environments without having to define variables that are not needed or throw a `KubernetesPluginException` if the value is null in the current environment.

## Goals
Avoid users having to specify all environment variables for DOCKER_USERNAME / DOCKER_PASSWORD / DOCKER_XXX when building locally but still use the environment variables when building in CICD.

## Approach
Remove throwing `KubernetesPluginException` and just set value to be "". See commit log for more details.

## Fixes
https://github.com/ballerina-platform/module-ballerina-kubernetes/issues/449