### PR TITLE
Revert "Bump httpClient version"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
     </scm>
 
     <properties>
-        <apache.http.client.version>4.5.13</apache.http.client.version>
+        <apache.http.client.version>4.5.10</apache.http.client.version>
         <ballerina.lang.version>1.2.33</ballerina.lang.version>
         <ballerina.source.directory>${project.build.directory}/../src/main/ballerina</ballerina.source.directory>
         <com.fasterxml.jackson.core.annotations.version>2.9.8</com.fasterxml.jackson.core.annotations.version>


### PR DESCRIPTION
Reverts ballerina-platform/module-ballerina-kubernetes#705
As it contains breaking changes. We can go ahead with older versions as per https://github.com/wso2-enterprise/internal-support-ballerina/issues/188#issuecomment-1261744928