### PR TITLE
Fix distributionManagement repository id collision

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,12 +384,12 @@
 
     <distributionManagement>
         <repository>
-            <id>wso2-nexus3</id>
+            <id>wso2-nexus3-releases</id>
             <name>Nexus3 Repository</name>
             <url>https://maven3-upgrade.wso2.org/nexus/repository/releases/</url>
         </repository>
         <snapshotRepository>
-            <id>wso2-nexus3</id>
+            <id>wso2-nexus3-snapshots</id>
             <name>Nexus3 Repository</name>
             <url>https://maven3-upgrade.wso2.org/nexus/repository/snapshots/</url>
         </snapshotRepository>


### PR DESCRIPTION
## Summary
- In `<distributionManagement>`, both `<repository>` and `<snapshotRepository>` used the same id `wso2-nexus3`, despite pointing at two different URLs (releases vs snapshots).
- This collides with the distinct `wso2-nexus3-releases` / `wso2-nexus3-snapshots` ids already declared under `<repositories>`, and can cause ambiguous credential/server-id resolution from `settings.xml` during deploy.
- Renames the ids to `wso2-nexus3-releases` and `wso2-nexus3-snapshots` respectively, matching the existing `<repositories>` entries.